### PR TITLE
Fix display of "Load From" button

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
 
 
 				<div class="mb-2 btn-group">
-					<div class="dropdown">
+					<div class="btn-group">
 						<button id="LoadFromButton" class="btn btn-primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">Load From</button>
 						<ul class="dropdown-menu">
 							<li><a class="dropdown-item" href="#" onclick="LoadFromFile()">Local File</a></li>


### PR DESCRIPTION
Had rounded corner on right side and didn't fill vertical space.
See https://getbootstrap.com/docs/5.0/components/button-group/#nesting