### PR TITLE
Rewrite addition and removal of properties to the selected document

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,10 +98,13 @@
 								<label class="input-group-text required-label w2" for="PackageSubfolder">Subfolder</label>
 								<input id="PackageSubfolder" class="form-control required" required />
 							</div>
-
 							<div class="input-group mb-2">
 								<label class="input-group-text w2" for="PackageDependencies">Dependencies</label>
-								<input id="PackageDependencies" class="form-control required" autocomplete="off">
+								<input id="PackageDependencies" class="form-control" autocomplete="off">
+							</div>
+							<div class="input-group mb-2">
+								<label class="input-group-text w2" for="PackageConflicting">Conflicting</label>
+								<input id="PackageConflicting" class="form-control" autocomplete="off">
 							</div>
 						</form>
 					</fieldset>

--- a/wwwroot/js/site-interactivity.js
+++ b/wwwroot/js/site-interactivity.js
@@ -167,6 +167,7 @@ function ResetPackageInputs() {
 	document.getElementById('PackageSubfolder').value = '';
 	pkgSubfolderSelect.clear(true);
 	pkgDependencySelect.clear(true);
+	pkgConflictingSelect.clear(true);
 	document.getElementById('PackageSummary').value = '';
 	document.getElementById('PackageConflicts').value = '';
 	document.getElementById('PackageWarning').value = '';
@@ -196,6 +197,16 @@ function FillPackageForm() {
 		} else {
 			deps.forEach((item) => {
 				pkgDependencySelect.addItem(item.value, true);
+			});
+		}
+	}
+	if (selectedDoc.has('conflicting')) {
+		let deps = (Array.isArray(selectedDoc.get('conflicting')) ? selectedDoc.get('conflicting') : selectedDoc.get('conflicting').items);
+		if (typeof (deps) === 'string') {
+			pkgConflictingSelect.addItem(deps, true);
+		} else {
+			deps.forEach((item) => {
+				pkgConflictingSelect.addItem(item.value, true);
 			});
 		}
 	}
@@ -326,6 +337,7 @@ function UpdatePackageData() {
 	UpdateProperty(['version'], document.getElementById('PackageVersion').value);
 	UpdateProperty(['subfolder'], document.getElementById('PackageSubfolder').value);
 	UpdateProperty(['dependencies'], pkgDependencySelect.getValue().split(','));
+	UpdateProperty(['conflicting'], pkgConflictingSelect.getValue().split(','));
 
 	UpdateProperty(['info', 'summary'], document.getElementById('PackageSummary').value);
 	UpdateProperty(['info', 'warning'], document.getElementById('PackageWarning').value);

--- a/wwwroot/js/site-interactivity.js
+++ b/wwwroot/js/site-interactivity.js
@@ -230,68 +230,68 @@ function FillPackageForm() {
 	document.getElementById('CurrentDocumentName').innerHTML = selectedDoc.get('group') + ':' + selectedDoc.get('name');
 }
 /**
+ * Updates, adds, or removes a property to the selected document at the specified index within the document.
+ * @param {Array} keys Property name(s); one or more strings.
+ * @param {any} values Property value(s) to set, either a string or an array of strings, or a eemeli/yaml object like a scalar
+ * @param {number} position Index in the document to insert this property to. Passing The index ensures serialization in the correct order resulting in a clean text representation with all the properties in the order we're expecting.
+ */
+function UpdateProperty(keys, values, position) {
+	if (selectedDoc === null) {
+		selectedDoc = new YAML.Document(new Object());
+	}
+	let current = selectedDoc.contents;
+
+	for (var idx = 0; idx < keys.length; idx++) {
+		const key = keys[idx];
+
+		if (idx === keys.length - 1) {
+			if (!values || values[0] === '' || (IsObject(values) && !values.value)) { //if '', null, undefined, empty array, array with one blank string, object with a blank value property
+				current.delete(key, values);
+				if (selectedDoc.has(keys[0])) {
+					if (selectedDoc.get(keys[0]).items.length === 0) {
+						selectedDoc.delete(keys[0]);
+					}
+				}
+				return;
+			}
+			else {
+				current.set(key, values);
+			}
+			break;
+		}
+
+		let next = current.get(key);
+		if (TypeOf(next) !== 'YAMLMap') {
+			next = new YAML.YAMLMap();
+			current.set(key, next);
+		}
+
+		current = next;
+	}
+}
+
+/**
  * Updates the selectedDoc with the current state of the Package Properties and Package Info tabs.
  */
 function UpdatePackageData() {
 	//TODO rename this function to metadata, also the asset function too
-	if (selectedDoc === null) {
-		selectedDoc = new YAML.Document(new Object());
-	}
+	
+	UpdateProperty(['group'], document.getElementById('PackageGroup').value, 0);
+	UpdateProperty(['name'], document.getElementById('PackageName').value, 1);
+	UpdateProperty(['version'], document.getElementById('PackageVersion').value, 2);
+	UpdateProperty(['subfolder'], document.getElementById('PackageSubfolder').value, 3);
+	UpdateProperty(['dependencies'], pkgDependencySelect.getValue().split(','), 4);
 
+	UpdateProperty(['info', 'summary'], document.getElementById('PackageSummary').value, 5);
+	UpdateProperty(['info', 'warning'], document.getElementById('PackageWarning').value, 5);
+	UpdateProperty(['info', 'conflicts'], document.getElementById('PackageConflicts').value, 5);
+	UpdateProperty(['info', 'author'], document.getElementById('PackageAuthor').value, 5);
+	UpdateProperty(['info', 'images'], pkgImageSelect.getValue().split(','), 5);
 
-	//#region Package Properties
-	if (document.getElementById('PackageGroup').value !== '') {
-		selectedDoc.setIn(['group'], document.getElementById('PackageGroup').value);
-	}
-	if (document.getElementById('PackageName').value !== '') {
-		selectedDoc.setIn(['name'], document.getElementById('PackageName').value);
-	}
-	if (document.getElementById('PackageVersion').value !== '') {
-		selectedDoc.setIn(['version'], document.getElementById('PackageVersion').value);
-	}
-	if (document.getElementById('PackageSubfolder').value !== '') {
-		selectedDoc.setIn(['subfolder'], document.getElementById('PackageSubfolder').value);
-	}
-	if (document.getElementById('PackageDependencies').value !== '') {
-		if (selectedDoc.get('dependencies') === undefined) {
-			const newSeq = selectedDoc.createNode([document.getElementById('PackageDependencies').value]);
-			newSeq.type = 'SEQ';
-			selectedDoc.set('dependencies', newSeq);
-		} else {
-			selectedDoc.get('dependencies').items = [];
-			pkgDependencySelect.getValue().split(',').forEach(dep => {
-				selectedDoc.get('dependencies').add(dep);
-			});
-		}
-	} else if (document.getElementById('PackageDependencies').value === '' && selectedDoc.has('dependencies')) {
-		selectedDoc.delete('dependencies');
-	}
-	//#endregion
+	let desc = new YAML.Scalar(document.getElementById('PackageDescription').value.replaceAll('"', "'"));
+	desc.type = 'BLOCK_LITERAL'; // Ensures the "|-" style is used
+	UpdateProperty(['info', 'description'], desc, 5);
 
-
-	//#region Package Info
-	if (document.getElementById('PackageSummary').value !== '') {
-		selectedDoc.setIn(['info', 'summary'], document.getElementById('PackageSummary').value);
-	}
-	if (document.getElementById('PackageWarning').value !== '') {
-		selectedDoc.setIn(['info', 'warning'], document.getElementById('PackageWarning').value);
-	}
-	if (document.getElementById('PackageConflicts').value !== '') {
-		selectedDoc.setIn(['info', 'conflicts'], document.getElementById('PackageConflicts').value);
-	}
-	if (document.getElementById('PackageDescription').value !== '') {
-		let scl = new YAML.Scalar(document.getElementById('PackageDescription').value.replaceAll('"', "'"));
-		scl.type = 'BLOCK_LITERAL'; // Ensures the "|-" style is used
-		selectedDoc.setIn(['info', 'description'], scl);
-	} else if (document.getElementById('PackageDescription').value === '' && selectedDoc.hasIn(['info', 'description'])) {
-		selectedDoc.deleteIn(['info', 'description']);
-	}
-	if (document.getElementById('PackageAuthor').value !== '') {
-		selectedDoc.setIn(['info', 'author'], document.getElementById('PackageAuthor').value);
-	}
-	if (document.getElementById('PackageImages').value !== '') {
-		selectedDoc.setIn(['info', 'images'], pkgImageSelect.getValue().split(','));
-	}
 	if (document.getElementById('PackageWebsite').value !== '') {
 		let sites = pkgWebsitesSelect.getValue().split(',');
 		if (sites.length > 1) {
@@ -313,7 +313,6 @@ function UpdatePackageData() {
 	} else if (selectedDoc.hasIn(['info', 'websites'])) {
 		selectedDoc.deleteIn(['info', 'websites']);
 	}
-	//#endregion
 
 
 	//#region Included Assets
@@ -326,7 +325,7 @@ function UpdatePackageData() {
 		newSeq.type = 'SEQ';
 		selectedDoc.set('assets', newSeq);
 		selectedPkgAssetIdx = 0;
-	} else if (selectedDoc.get('assets') !== undefined) {
+	} else if (selectedDoc.has('assets') && selectedPkgAssetIdx != null) {
 		let assetItem = selectedDoc.get('assets').items[selectedPkgAssetIdx];
 		if (document.getElementById('PackageAssetInclude').value !== '') {
 			if (assetItem.get('include') === undefined) {
@@ -451,41 +450,14 @@ function FillAssetForm() {
  * Updates the selectedDoc with the current state of the Asset Properties tab inputs.
  */
 function UpdateAssetData() {
-	if (selectedDoc === null) {
-		selectedDoc = new YAML.Document(new Object());
-	}
-
-	if (document.getElementById('AssetUrl').value !== '') {
-		selectedDoc.setIn(['url'], document.getElementById('AssetUrl').value);
-	}
-	if (document.getElementById('AssetId').value !== '') {
-		selectedDoc.setIn(['assetId'], document.getElementById('AssetId').value);
-	}
-	if (document.getElementById('AssetVersion').value !== '') {
-		selectedDoc.setIn(['version'], document.getElementById('AssetVersion').value);
-	}
-	if (document.getElementById('AssetLastModified').value !== '') {
-		selectedDoc.setIn(['lastModified'], document.getElementById('AssetLastModified').value + 'Z');
-	}
-	if (document.getElementById('AssetArchiveVersion').value !== '0') {
-		selectedDoc.setIn(['archiveType', 'format'], document.getElementById('AssetArchiveFormat').value);
-		selectedDoc.setIn(['archiveType', 'version'], document.getElementById('AssetArchiveVersion').value);
-	} else {
-		selectedDoc.deleteIn(['archiveType']);
-	}
-	if (document.getElementById('AssetChecksum').value !== '') {
-		if (!selectedDoc.has('checksum')) {
-			selectedDoc.checksum = new Object();
-		}
-		selectedDoc.setIn(['checksum', 'sha256'], document.getElementById('AssetChecksum').value);
-	} else {
-		selectedDoc.deleteIn(['checksum']);
-	}
-	if (document.getElementById('AssetNonPersistentUrl').value !== '') {
-		selectedDoc.setIn(['nonPersistentUrl'], document.getElementById('AssetNonPersistentUrl').value);
-	} else {
-		selectedDoc.deleteIn(['nonPersistentUrl']);
-	}
+	UpdateProperty(['assetId'], document.getElementById('AssetId').value, 0);
+	UpdateProperty(['url'], document.getElementById('AssetUrl').value, 1);
+	UpdateProperty(['version'], document.getElementById('AssetVersion').value, 2);
+	UpdateProperty(['lastModified'], (document.getElementById('AssetLastModified').value === '' ? '' : document.getElementById('AssetLastModified').value + 'Z'), 3);
+	UpdateProperty(['nonPersistentUrl'], document.getElementById('AssetNonPersistentUrl').value, 6);
+	UpdateProperty(['checksum', 'sha256'], document.getElementById('AssetChecksum').value, 7);
+	UpdateProperty(['archiveType', 'format'], document.getElementById('AssetArchiveVersion').value === '0' ? '' : document.getElementById('AssetArchiveFormat').value, 8);
+	UpdateProperty(['archiveType', 'version'], document.getElementById('AssetArchiveVersion').value === '0' ? '' : document.getElementById('AssetArchiveVersion').value, 8);
 
 	//To push the package to the list it at minimum must have an assetId
 	if (currDocIdx === null && selectedDoc.has('assetId')) {

--- a/wwwroot/js/site-interactivity.js
+++ b/wwwroot/js/site-interactivity.js
@@ -233,9 +233,52 @@ function FillPackageForm() {
  * Updates, adds, or removes a property to the selected document at the specified index within the document.
  * @param {Array} keys Property name(s); one or more strings.
  * @param {any} values Property value(s) to set, either a string or an array of strings, or a eemeli/yaml object like a scalar
- * @param {number} position Index in the document to insert this property to. Passing The index ensures serialization in the correct order resulting in a clean text representation with all the properties in the order we're expecting.
  */
 function UpdateProperty(keys, values, position) {
+	/** Index in the document to insert this property to. Passing The index ensures serialization in the correct order resulting in a clean text representation with all the properties in the order we're expecting. This index is scoped to only each item's parent property. */
+	const nodePositions = {
+		//Package properties
+		group: 0
+		, name: 1
+		, version: 2
+		, subfolder: 3
+		, dependencies: 4
+		, conflicting: 5
+		, info: 6
+		, assets: 7
+		, variants: 8
+		, variantInfo: 9
+
+		//Package.Info properties
+		, summary: 0
+		, warning: 1
+		, conflicts: 2
+		, description: 3
+		, author: 4
+		, images: 5
+		, website: 6
+		, websites: 6
+
+		//Package.Varaints properties
+		, variant: 0
+		//`dependencies` is already 4
+		//`assets` is already 7
+
+		//Package.Variants.Variant properties
+		//`assetId` is already 0
+		, include: 1
+		, exclude: 2
+
+		//Asset properties
+		, assetId: 0
+		, url: 1
+		//`version` is already 2
+		, lastModified: 3
+		, checksum: 4
+		, nonPersistentUrl: 5
+		, archiveType: 6
+	}
+
 	if (selectedDoc === null) {
 		selectedDoc = new YAML.Document(new Object());
 	}
@@ -252,10 +295,14 @@ function UpdateProperty(keys, values, position) {
 						selectedDoc.delete(keys[0]);
 					}
 				}
-				return;
+				break;
 			}
 			else {
-				current.set(key, values);
+				if (selectedDoc.hasIn(keys)) {
+					current.set(key, values);
+				} else {
+					current.items.splice(nodePositions[key] ?? 0, 0, new YAML.Pair(key, values)); // `?? 0` returns 0 in case the lookup is undefined (key is not in nodePositions)
+				}
 			}
 			break;
 		}
@@ -263,7 +310,7 @@ function UpdateProperty(keys, values, position) {
 		let next = current.get(key);
 		if (TypeOf(next) !== 'YAMLMap') {
 			next = new YAML.YAMLMap();
-			current.set(key, next);
+			current.items.splice(nodePositions[key] ?? 0, 0, new YAML.Pair(key, next));
 		}
 
 		current = next;
@@ -271,47 +318,32 @@ function UpdateProperty(keys, values, position) {
 }
 
 /**
- * Updates the selectedDoc with the current state of the Package Properties and Package Info tabs.
+ * Updates the selectedDoc with the current state of the Package Properties, Package Info, and Package Asset tabs.
  */
 function UpdatePackageData() {
-	//TODO rename this function to metadata, also the asset function too
-	
-	UpdateProperty(['group'], document.getElementById('PackageGroup').value, 0);
-	UpdateProperty(['name'], document.getElementById('PackageName').value, 1);
-	UpdateProperty(['version'], document.getElementById('PackageVersion').value, 2);
-	UpdateProperty(['subfolder'], document.getElementById('PackageSubfolder').value, 3);
-	UpdateProperty(['dependencies'], pkgDependencySelect.getValue().split(','), 4);
+	UpdateProperty(['group'], document.getElementById('PackageGroup').value);
+	UpdateProperty(['name'], document.getElementById('PackageName').value);
+	UpdateProperty(['version'], document.getElementById('PackageVersion').value);
+	UpdateProperty(['subfolder'], document.getElementById('PackageSubfolder').value);
+	UpdateProperty(['dependencies'], pkgDependencySelect.getValue().split(','));
 
-	UpdateProperty(['info', 'summary'], document.getElementById('PackageSummary').value, 5);
-	UpdateProperty(['info', 'warning'], document.getElementById('PackageWarning').value, 5);
-	UpdateProperty(['info', 'conflicts'], document.getElementById('PackageConflicts').value, 5);
-	UpdateProperty(['info', 'author'], document.getElementById('PackageAuthor').value, 5);
-	UpdateProperty(['info', 'images'], pkgImageSelect.getValue().split(','), 5);
+	UpdateProperty(['info', 'summary'], document.getElementById('PackageSummary').value);
+	UpdateProperty(['info', 'warning'], document.getElementById('PackageWarning').value);
+	UpdateProperty(['info', 'conflicts'], document.getElementById('PackageConflicts').value);
+	UpdateProperty(['info', 'author'], document.getElementById('PackageAuthor').value);
+	UpdateProperty(['info', 'images'], pkgImageSelect.getValue().split(','));
 
 	let desc = new YAML.Scalar(document.getElementById('PackageDescription').value.replaceAll('"', "'"));
 	desc.type = 'BLOCK_LITERAL'; // Ensures the "|-" style is used
-	UpdateProperty(['info', 'description'], desc, 5);
+	UpdateProperty(['info', 'description'], desc);
 
-	if (document.getElementById('PackageWebsite').value !== '') {
-		let sites = pkgWebsitesSelect.getValue().split(',');
-		if (sites.length > 1) {
-			if (selectedDoc.hasIn(['info', 'websites'])) {
-				selectedDoc.getIn(['info', 'websites']).items = [];
-			} else {
-				selectedDoc.addIn(['info', 'websites'], []);
-			}
-			sites.forEach(site => {
-				selectedDoc.getIn(['info', 'websites']).add(site);
-			});
-			selectedDoc.deleteIn(['info', 'website']);
-		} else {
-			selectedDoc.setIn(['info', 'website'], sites[0]);
-			selectedDoc.deleteIn(['info', 'websites']);
-		}
-	} else if (selectedDoc.hasIn(['info', 'website'])) {
-		selectedDoc.deleteIn(['info', 'website']);
-	} else if (selectedDoc.hasIn(['info', 'websites'])) {
-		selectedDoc.deleteIn(['info', 'websites']);
+	const sites = pkgWebsitesSelect.getValue().split(',');
+	if (sites.length > 1) {
+		UpdateProperty(['info', 'websites'], sites);
+		UpdateProperty(['info', 'website'], '');
+	} else {
+		UpdateProperty(['info', 'website'], sites);
+		UpdateProperty(['info', 'websites'], '');
 	}
 
 
@@ -450,14 +482,14 @@ function FillAssetForm() {
  * Updates the selectedDoc with the current state of the Asset Properties tab inputs.
  */
 function UpdateAssetData() {
-	UpdateProperty(['assetId'], document.getElementById('AssetId').value, 0);
-	UpdateProperty(['url'], document.getElementById('AssetUrl').value, 1);
-	UpdateProperty(['version'], document.getElementById('AssetVersion').value, 2);
-	UpdateProperty(['lastModified'], (document.getElementById('AssetLastModified').value === '' ? '' : document.getElementById('AssetLastModified').value + 'Z'), 3);
-	UpdateProperty(['nonPersistentUrl'], document.getElementById('AssetNonPersistentUrl').value, 6);
-	UpdateProperty(['checksum', 'sha256'], document.getElementById('AssetChecksum').value, 7);
-	UpdateProperty(['archiveType', 'format'], document.getElementById('AssetArchiveVersion').value === '0' ? '' : document.getElementById('AssetArchiveFormat').value, 8);
-	UpdateProperty(['archiveType', 'version'], document.getElementById('AssetArchiveVersion').value === '0' ? '' : document.getElementById('AssetArchiveVersion').value, 8);
+	UpdateProperty(['assetId'], document.getElementById('AssetId').value);
+	UpdateProperty(['url'], document.getElementById('AssetUrl').value);
+	UpdateProperty(['version'], document.getElementById('AssetVersion').value);
+	UpdateProperty(['lastModified'], (document.getElementById('AssetLastModified').value === '' ? '' : document.getElementById('AssetLastModified').value + 'Z'));
+	UpdateProperty(['nonPersistentUrl'], document.getElementById('AssetNonPersistentUrl').value);
+	UpdateProperty(['checksum', 'sha256'], document.getElementById('AssetChecksum').value);
+	UpdateProperty(['archiveType', 'format'], document.getElementById('AssetArchiveVersion').value === '0' ? '' : document.getElementById('AssetArchiveFormat').value);
+	UpdateProperty(['archiveType', 'version'], document.getElementById('AssetArchiveVersion').value === '0' ? '' : document.getElementById('AssetArchiveVersion').value);
 
 	//To push the package to the list it at minimum must have an assetId
 	if (currDocIdx === null && selectedDoc.has('assetId')) {

--- a/wwwroot/js/site-load.js
+++ b/wwwroot/js/site-load.js
@@ -23,7 +23,8 @@ const ChannelInfo = [
 	{ name: 'local', url: null, label: 'This file' },
 	{ name: 'default', url: 'https://memo33.github.io/sc4pac/channel/sc4pac-channel-contents.json', label: 'Default channel' },
 	{ name: 'simtrop', url: 'https://sc4pac.simtropolis.com/sc4pac-channel-contents.json', label: 'Simtropolis channel' },
-    { name: 'zasco', url: 'https://zasco.github.io/sc4pac-channel/channel/sc4pac-channel-contents.json', label: 'Zasco\'s channel' },
+    //{ name: 'zasco', url: 'https://zasco.github.io/sc4pac-channel/channel/sc4pac-channel-contents.json', label: 'Zasco\'s channel' },
+    { name: 'sc4ever', url: 'https://sc4evermore.github.io/sc4pac-channel/channel/sc4pac-channel-contents.json', label: 'SC4Evermore channel'},
 ];
 void LoadData();
 

--- a/wwwroot/js/site-load.js
+++ b/wwwroot/js/site-load.js
@@ -56,6 +56,7 @@ async function LoadData() {
     pkgGroupSelect.addOptions(AllGroups.map(grp => ({ value: grp, text: grp })));
     pkgSubfolderSelect.addOptions(AllSubfolders.map(folder => ({ value: folder, text: folder })));
     pkgDependencySelect.addOptions(AllPackages.map(pkg => ({ value: pkg.id, id: pkg.id, channel: pkg.channel })));
+    pkgConflictingSelect.addOptions(AllPackages.map(pkg => ({ value: pkg.id, id: pkg.id, channel: pkg.channel })));
     pkgAssetSelect.addOptions(AllAssets.map(asset => ({ value: asset.id, id: asset.id, channel: asset.channel })));
     variantDependencySelect.addOptions(AllPackages.map(pkg => ({ value: pkg.id, id: pkg.id, channel: pkg.channel })));
     variantAssetSelect.addOptions(AllAssets.map(asset => ({ value: asset.id, id: asset.id, channel: asset.channel })));

--- a/wwwroot/js/site-util.js
+++ b/wwwroot/js/site-util.js
@@ -35,7 +35,18 @@ function IsPackage(obj) {
  * @returns The name of the object's constructor as a string
  */
 function TypeOf(obj) {
+	if (obj === undefined) {
+		return 'undefined';
+	}
 	return obj.__proto__.constructor.name
+}
+/**
+ * Determine whether the specified item is an Object.
+ * @param {any} obj An item to analyze
+ * @returns TRUE if the item is an object; FALSE otherwise.
+ */
+function IsObject(obj) {
+	return (typeof obj === "object" && !Array.isArray(obj) && obj !== null);
 }
 /**
  * Calculate similarity between two strings

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -166,9 +166,19 @@ const pkgDependencySelect = new TomSelect("#PackageDependencies", {
 	render: {
 		option: function (item, escape) {
 			return '<div class="py-2 d-flex">' + escape(item.id) + '</div>';
-		},
-		optgroup_header: function (data, escape) {
-			return '<div class="optgroup-label">' + escape(data.label) + '</span></div>';
+		}
+	}
+});
+
+const pkgConflictingSelect = new TomSelect("#PackageConflicting", {
+	create: false,
+	valueField: 'value',
+	labelField: 'id',
+	searchField: ['id'],
+
+	render: {
+		option: function (item, escape) {
+			return '<div class="py-2 d-flex">' + escape(item.id) + '</div>';
 		}
 	}
 });


### PR DESCRIPTION
Improves the addition and removal of properties to the selected document by moving logic to a single function which handles the addition, deletion, and updating of the property value. Also adds the feature to insert new properties in a designated order, instead of the newest one always being added to the end. The Package Assets and Package Variants still need to be done due to their complexity.

Closes #119, closes #116, and closes #115 which was fixed along with these commits.