### PR TITLE
Fix CodeMirror scroll heights

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
 	</header>
 
 
-	<main role="main" class="container flex-shrink-0">
-		<div style="display:flex" class="row">
+	<main role="main" class="container flex-grow-1 overflow-hidden">
+		<div style="display:flex" class="row h-100">
 
 			<!-- Left Column -->
 			<div id="Column0" class="col-sm-12 col-md-2">
@@ -424,7 +424,7 @@
 				<p>The content in this code pane is automatically generated from the inputs on the left, but may also be customized manually. YAML written here must be syntactically valid.</p>
 
 
-				<div class="mb-2 btn-group">
+				<div class="mb-2 btn-group align-self-start">
 					<div class="btn-group">
 						<button id="LoadFromButton" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">Load From</button>
 						<ul class="dropdown-menu">
@@ -437,8 +437,8 @@
 					</div>
 					<button id="CopyToClipButton" class="btn btn-primary" type="button">Copy to Clipboard</button>
 					<button id="SaveAsButton" class="btn btn-primary" type="button">Save As</button>
+					<button id="OpenPreferencesButton" class="btn btn-sucess" type="button">Preferences</button>
 					<button id="ClearAllButton" class="btn btn-danger" type="button">Clear All</button>
-					<button id="OpenPreferencesButton" class="btn btn-success" type="button">Preferences</button>
 					<!--<button id="StexFetch" class="btn btn-info" type="button">STEX Fetch</button>-->
 				</div>
 

--- a/index.html
+++ b/index.html
@@ -437,7 +437,7 @@
 					</div>
 					<button id="CopyToClipButton" class="btn btn-primary" type="button">Copy to Clipboard</button>
 					<button id="SaveAsButton" class="btn btn-primary" type="button">Save As</button>
-					<button id="OpenPreferencesButton" class="btn btn-sucess" type="button">Preferences</button>
+					<button id="OpenPreferencesButton" class="btn btn-success" type="button">Preferences</button>
 					<button id="ClearAllButton" class="btn btn-danger" type="button">Clear All</button>
 					<!--<button id="StexFetch" class="btn btn-info" type="button">STEX Fetch</button>-->
 				</div>

--- a/wwwroot/css/site.css
+++ b/wwwroot/css/site.css
@@ -16,7 +16,7 @@ html {
 }
 
 body {
-  margin-bottom: 60px;
+  margin-bottom: 0;
 }
 
 .EasyMDEContainer {
@@ -25,17 +25,12 @@ body {
 .box {
     display: flex;
     flex-flow: column;
-    height: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
 }
 .CodeMirror {
     border: 1px solid lightgrey;
     /*flex: 1 1 auto;*/
-}
-.CodeMirror-scroll {
-}
-
-.required {
-    /*border-color:dodgerblue;*/
 }
 
 .required-label:after {
@@ -84,12 +79,18 @@ body {
         font-weight: bold;
     }
 
-#Column0, #Column1, #Column2 {
-    /*border: 1px solid black;*/
+/* Right column: fills remaining page height so CodeMirror never causes page scroll */
+#Column2 {
+    height: 100%;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
 }
 /* This is the code editor */
 .CodeMirror.cm-s-default {
-    height: 75%;
+    flex: 1 1 auto;
+    height: 100%;
+    min-height: 0;
     font-size: .95em;
 }
 /* This is the markdown editor */

--- a/wwwroot/js/site-interactivity.js
+++ b/wwwroot/js/site-interactivity.js
@@ -77,6 +77,7 @@ function ClearAll() {
 	document.getElementById('YamlFileName').textContent = '';
 	currDocIdx = null;
 	UpdateData();
+	FillVariantInfoTab();
 }
 
 

--- a/wwwroot/js/site-variant-info.js
+++ b/wwwroot/js/site-variant-info.js
@@ -70,7 +70,7 @@ function FillVariantInfoTab() {
 
 		const card = document.createElement('div');
 		card.className = 'card mb-3';
-		card.dataset.variantKey = key;
+		card.dataset.variantId = key;
 
 		const cardHdr = document.createElement('div');
 		cardHdr.className = 'card-header';
@@ -138,7 +138,7 @@ function FillVariantInfoTab() {
 				return function () {
 					// Uncheck all other default checkboxes in this card
 					if (this.checked) {
-						const card = capturedCheckbox.closest('[data-variant-key]');
+						const card = capturedCheckbox.closest('[data-variant-id]');
 						if (card) {
 							card.querySelectorAll('input[type="checkbox"]').forEach(cb => {
 								if (cb !== capturedCheckbox) cb.checked = false;
@@ -164,14 +164,14 @@ function FillVariantInfoTab() {
 
 /**
  * Reads the variantInfo section from selectedDoc and returns it as a plain JS object.
- * @returns {Object} Map of variantKey → { description, values: { value → { description, default } } }
+ * @returns {Object} Map of variantId → { description, values: { value → { description, default } } }
  */
 function ReadVariantInfoFromDoc() {
 	const result = {};
 	if (!selectedDoc || !selectedDoc.has('variantInfo')) return result;
 
 	selectedDoc.get('variantInfo').items.forEach(item => {
-		const vKey = item.get('variantKey');
+		const vKey = item.get('variantId');
 		if (!vKey) return;
 		result[vKey] = { description: item.get('description') ?? '', values: {} };
 		if (item.has('values')) {
@@ -191,10 +191,10 @@ function ReadVariantInfoFromDoc() {
 
 /**
  * Returns the variantInfo map item for the given key, creating it if necessary.
- * @param {string} variantKey
+ * @param {string} variantId
  * @returns The YAML map item for this key
  */
-function GetOrCreateVariantKeyItem(variantKey) {
+function GetOrCreateVariantKeyItem(variantId) {
 	if (!selectedDoc.has('variantInfo')) {
 		const newSeq = selectedDoc.createNode([]);
 		newSeq.type = 'SEQ';
@@ -202,9 +202,9 @@ function GetOrCreateVariantKeyItem(variantKey) {
 	}
     
 	const items = selectedDoc.get('variantInfo').items;
-	let item = items.find(i => i.get('variantKey') === variantKey);
+	let item = items.find(i => i.get('variantId') === variantId);
 	if (!item) {
-		item = selectedDoc.createNode({ variantKey });
+		item = selectedDoc.createNode({ variantId });
 		selectedDoc.get('variantInfo').add(item);
 	}
 	return item;
@@ -234,11 +234,11 @@ function GetOrCreateVariantValueItem(keyItem, value) {
 
 /**
  * Writes the description for a variant key to selectedDoc and updates data.
- * @param {string} variantKey
+ * @param {string} variantId
  * @param {string} description
  */
-function WriteVariantKeyDescription(variantKey, description) {
-	const item = GetOrCreateVariantKeyItem(variantKey);
+function WriteVariantKeyDescription(variantId, description) {
+	const item = GetOrCreateVariantKeyItem(variantId);
 	if (description) {
 		item.set('description', description);
 	} else {
@@ -249,12 +249,12 @@ function WriteVariantKeyDescription(variantKey, description) {
 
 /**
  * Writes the description for a specific variant value to selectedDoc and updates data.
- * @param {string} variantKey
+ * @param {string} variantId
  * @param {string} value
  * @param {string} description
  */
-function WriteVariantValueDescription(variantKey, value, description) {
-	const keyItem = GetOrCreateVariantKeyItem(variantKey);
+function WriteVariantValueDescription(variantId, value, description) {
+	const keyItem = GetOrCreateVariantKeyItem(variantId);
 	if (description) {
 		const valItem = GetOrCreateVariantValueItem(keyItem, value);
 		valItem.set('description', description);
@@ -276,12 +276,12 @@ function WriteVariantValueDescription(variantKey, value, description) {
 
 /**
  * Writes the default flag for a specific variant value to selectedDoc and updates data.
- * @param {string} variantKey
+ * @param {string} variantId
  * @param {string} value
  * @param {boolean} isDefault
  */
-function WriteVariantValueDefault(variantKey, value, isDefault) {
-	const keyItem = GetOrCreateVariantKeyItem(variantKey);
+function WriteVariantValueDefault(variantId, value, isDefault) {
+	const keyItem = GetOrCreateVariantKeyItem(variantId);
 	if (isDefault) {
 		// Clear the default flag from all other value entries for this key
 		if (keyItem.has('values')) {

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -327,7 +327,7 @@ function UpdateData(dumpData = true) {
 	UpdateConditionTree();
 	UpdateVariantTree();
 	UpdateVariantAssetTree();
-	FillVariantInfoTab();
+	if (!dumpData) FillVariantInfoTab();
 
 	function DumpYaml() {
 		if (yamlData.length === 0) {

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -316,9 +316,11 @@ function UpdateData(dumpData = true) {
 	});
 
 	if (dumpData) {
+		const scrollInfo = cm.getScrollInfo();
 		cm.off('change', CodeMirrorOnChange);
 		cm.setValue(DumpYaml());
 		cm.on('change', CodeMirrorOnChange);
+		cm.scrollTo(scrollInfo.left, scrollInfo.top);
 	}
 	
 	SetSelectedDoc(currDocIdx);


### PR DESCRIPTION
Editing longer YAML documents caused the CodeMirror element to expand in height past the edge of the page, causing a scroll bar in both the CodeMirror element and the page. This locks the height of the code element to the height of the page, so there is only scrolling in the code element. However, the page will still scroll due to elements in other columns. Thanks to Claude or I never would have figured out this CSS.

Fixes #88.

Also fixes other misc bugs.